### PR TITLE
ci: Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,10 @@ go:
 - "1.11"
 - master
 
-before_install:
-  # Setup `dep`
-  # - curl -L -s https://github.com/golang/dep/releases/download/v0.3.1/dep-linux-amd64 -o $GOPATH/bin/dep
-  # - chmod +x $GOPATH/bin/dep
-
-#install:
-  #- (cd cli && dep ensure)
+matrix:
+  allow_failures:
+  - go: master
+  fast_finish: true
 
 script: 
   - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 
 go:
-- 1.9
+- "1.9"
+- "1.10"
+- "1.11"
 - master
 
 before_install:

--- a/cli/indexcmd.go
+++ b/cli/indexcmd.go
@@ -70,7 +70,7 @@ var IndexCmd = cli.Command{
 		})
 
 		if loadErr != nil {
-			return NewInternalError("failed to parse wiki archive", 10)
+			return NewInternalError("failed to parse wiki archive")
 		}
 
 		close(articles)

--- a/test.sh
+++ b/test.sh
@@ -6,9 +6,13 @@ set -e
 echo "" > coverage.txt
 
 for d in $(go list ./... | grep -v vendor); do
-    go test -race -coverprofile=profile.out -covermode=atomic $d
+	# Run tests with coverage
+    go test -v -race -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt
         rm profile.out
     fi
+
+	# lint
+	go vet $d
 done

--- a/wp/loadwiki.go
+++ b/wp/loadwiki.go
@@ -167,8 +167,6 @@ func LoadWiki(source io.Reader, visitor func(*Article) bool) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 // linkRegex extracts links from wikitext.


### PR DESCRIPTION
 - Add go 1.10 and 1.11 to .travis.yml test matrix
 - Add linting with `go vet` to the tests. Lint errors fail CI.
 - Fix some lint/testing errors.